### PR TITLE
Feature: 회원가입 api 만들기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -35,6 +37,11 @@ dependencies {
 
     // Dotenv (환경 변수 관리 .env 파일 사용)
     implementation 'io.github.cdimascio:dotenv-java:2.2.0'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.giho.king_of_table_tennis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+      .csrf(AbstractHttpConfigurer::disable) // csrf disable
+      .formLogin(AbstractHttpConfigurer::disable) // Form 로그인 방식 disable
+      .httpBasic(AbstractHttpConfigurer::disable) // http basic 인증 방식 disable
+      .authorizeHttpRequests((auth) -> auth // 경로별 인가 작업
+        .requestMatchers("/login", "/", "/join").permitAll()
+        .requestMatchers("/admin").hasRole("ADMIN")
+        .anyRequest().authenticated()
+      )
+      .sessionManagement((session) -> session // 세션 설정
+        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+      );
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -26,7 +26,9 @@ public class SecurityConfig {
       .formLogin(AbstractHttpConfigurer::disable) // Form 로그인 방식 disable
       .httpBasic(AbstractHttpConfigurer::disable) // http basic 인증 방식 disable
       .authorizeHttpRequests((auth) -> auth // 경로별 인가 작업
-        .requestMatchers("/login", "/", "/join").permitAll()
+        .requestMatchers(
+          "/api/auth/**"
+        ).permitAll()
         .requestMatchers("/admin").hasRole("ADMIN")
         .anyRequest().authenticated()
       )

--- a/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.giho.king_of_table_tennis.controller;
+
+import com.giho.king_of_table_tennis.dto.RegisterDTO;
+import com.giho.king_of_table_tennis.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("register")
+  public ResponseEntity<String> register(RegisterDTO registerDTO) {
+
+    boolean response = authService.register(registerDTO);
+
+    if (response) {
+      return ResponseEntity.ok("회원가입에 성공했습니다.");
+    } else {
+      return ResponseEntity.ok("회원가입에 실패했습니다.");
+    }
+
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/RegisterDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/RegisterDTO.java
@@ -1,0 +1,15 @@
+package com.giho.king_of_table_tennis.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class RegisterDTO {
+  private String id;
+  private String password;
+  private String name;
+  private String nickName;
+  private String email;
+  private String profileImage;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/UserEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/UserEntity.java
@@ -1,29 +1,34 @@
 package com.giho.king_of_table_tennis.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-@Entity
 @Getter
 @Setter
+@Entity
+@Table(name = "user")
 public class UserEntity {
 
   @Id
+  @Column(name = "id", nullable = false, unique = true)
   private String id;
 
+  @Column(name = "password", nullable = false)
   private String password;
 
+  @Column(name = "name", nullable = false)
   private String name;
 
+  @Column(name = "nick_name", nullable = false)
   private String nickName;
 
+  @Column(name = "email", nullable = false)
   private String email;
 
+  @Column(name = "profile_image", nullable = false)
   private String profileImage;
 
+  @Column(name = "role", nullable = false)
   private String role;
 }

--- a/src/main/java/com/giho/king_of_table_tennis/entity/UserEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/UserEntity.java
@@ -1,0 +1,29 @@
+package com.giho.king_of_table_tennis.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class UserEntity {
+
+  @Id
+  private String id;
+
+  private String password;
+
+  private String name;
+
+  private String nickName;
+
+  private String email;
+
+  private String profileImage;
+
+  private String role;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserEntity, String> {
 
-
+  boolean existsById(String id);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.giho.king_of_table_tennis.repository;
+
+import com.giho.king_of_table_tennis.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, String> {
+
+
+}

--- a/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
@@ -1,0 +1,39 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.RegisterDTO;
+import com.giho.king_of_table_tennis.entity.UserEntity;
+import com.giho.king_of_table_tennis.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+  public boolean register(RegisterDTO registerDTO) {
+
+    boolean isExistUser = userRepository.existsById(registerDTO.getId());
+
+    if (isExistUser) {
+      return false;
+    }
+
+    UserEntity userEntity = new UserEntity();
+
+    userEntity.setId(registerDTO.getId());
+    userEntity.setPassword(bCryptPasswordEncoder.encode(registerDTO.getPassword()));
+    userEntity.setName(registerDTO.getName());
+    userEntity.setNickName(registerDTO.getNickName());
+    userEntity.setEmail(registerDTO.getEmail());
+    userEntity.setProfileImage(registerDTO.getProfileImage());
+    userEntity.setRole("ROLE_USER");
+
+    userRepository.save(userEntity);
+
+    return true;
+  }
+}


### PR DESCRIPTION
## 개요
- Spring Security 설정 및 user 테이블 연동
- 회원가입 api 구현

## 작업 내용
- Spring Security 설정
  - BCryptPasswordEncoder와 SecurityFilterChain 설정
  - requestMatchers의 permitAll에 "/api/auth/**" 추가하여 인증 없이 접근 가능하도록 설정

- 회원가입 api 만들고 user 테이블에 저장되도록 함

- user 테이블
```sql
CREATE TABLE user (
    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
    password VARCHAR(255) NOT NULL,
    name VARCHAR(255) NOT NULL,
    nick_name VARCHAR(255) NOT NULL,
    email VARCHAR(255) NOT NULL,
    profile_image VARCHAR(255) NOT NULL,
    role VARCHAR(10) NOT NULL
);
```

## 테스트 방법
- Postman으로 'POST /api/auth/register' 호출
- 요청 body에 id와 password, name, nickName, email, profileImage 전달 시 DB에 사용자 저장 확인