### PR TITLE
feature: UsernamePasswordAuthenticationFilter를 custom한 loginFilter로 대체를 통해 로그인 구현

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -1,17 +1,30 @@
 package com.giho.king_of_table_tennis.config;
 
+import com.giho.king_of_table_tennis.jwt.LoginFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final AuthenticationConfiguration authenticationConfiguration;
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+    return configuration.getAuthenticationManager();
+  }
 
   @Bean
   public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -27,11 +40,13 @@ public class SecurityConfig {
       .httpBasic(AbstractHttpConfigurer::disable) // http basic 인증 방식 disable
       .authorizeHttpRequests((auth) -> auth // 경로별 인가 작업
         .requestMatchers(
-          "/api/auth/**"
+          "/api/auth/**",
+          "/login"
         ).permitAll()
         .requestMatchers("/admin").hasRole("ADMIN")
         .anyRequest().authenticated()
       )
+      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
       .sessionManagement((session) -> session // 세션 설정
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       );

--- a/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.giho.king_of_table_tennis.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -15,7 +16,7 @@ public class AuthController {
 
   private final AuthService authService;
 
-  @PostMapping("register")
+  @PostMapping("/register")
   public ResponseEntity<String> register(RegisterDTO registerDTO) {
 
     boolean response = authService.register(registerDTO);

--- a/src/main/java/com/giho/king_of_table_tennis/dto/CustomUserDetails.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/CustomUserDetails.java
@@ -1,0 +1,62 @@
+package com.giho.king_of_table_tennis.dto;
+
+import com.giho.king_of_table_tennis.entity.UserEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+  private final UserEntity userEntity;
+
+  public CustomUserDetails(UserEntity userEntity) {
+    this.userEntity = userEntity;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+
+    Collection<GrantedAuthority> collection = new ArrayList<>();
+
+    collection.add(new GrantedAuthority() {
+      @Override
+      public String getAuthority() {
+        return userEntity.getRole();
+      }
+    });
+
+    return collection;
+  }
+
+  @Override
+  public String getPassword() {
+    return userEntity.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return userEntity.getId();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
@@ -1,0 +1,43 @@
+package com.giho.king_of_table_tennis.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+  private final AuthenticationManager authenticationManager;
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+    // 클라이언트 요청에서 username, password 추출
+    String username = obtainUsername(request);
+    String password = obtainPassword(request);
+
+    // spring security에서 username과 password를 검증하기 위해 token에 담아야 함
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+    // token에 담은 검증을 위한 AuthenticationManager로 전달
+    return authenticationManager.authenticate(authToken);
+  }
+
+  // 로그인 성공 시 실행하는 메소드 (여기서 JWT 발급)
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    System.out.println("로그인 성공");
+  }
+
+  // 로그인 실패 시 실행하는 메소드
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+    System.out.println("로그인 실패");
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/service/CustomUserDetailsService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.CustomUserDetails;
+import com.giho.king_of_table_tennis.entity.UserEntity;
+import com.giho.king_of_table_tennis.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+    UserEntity userEntity = userRepository.findById(username).orElse(null);
+
+    if (userEntity != null) {
+      return new CustomUserDetails(userEntity);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## 개요
- LoginFilter 생성
- CustomUserDetails 생성
- 로그인 api 구현

## 작업 내용
- UsernamePasswordAuthenticationFilter를 대체할 loginFilter 생성
  - SecurityConfig에서 addFilterAt를 통해 대체
- successfulAuthentication과 unsuccessfulAuthentication을 통해 로그인 성공/실패 여부 출력(아직 JWT 구현을 하지 않아 토큰 반환 X)

## 테스트 방법
Postman으로 'POST /login' 호출
요청 body에 username(아이디)와 password 전달 시 DB에 사용자 확인 후 200 반환, System.out.println으로 "로그인 성공/실패" 출력함