### PR TITLE
feature: JWTUtil을 통한 토큰 생성 / 로그인 성공 시 헤더에 포함시켜 반환

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
+++ b/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
@@ -13,6 +13,7 @@ public class KingOfTableTennisApplication {
     Dotenv dotenv = Dotenv.configure().load();
 
     System.setProperty("MYSQL_PASSWORD", dotenv.get("MYSQL_PASSWORD"));
+    System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
 
     SpringApplication.run(KingOfTableTennisApplication.class, args);
   }

--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.giho.king_of_table_tennis.config;
 
+import com.giho.king_of_table_tennis.jwt.JWTUtil;
 import com.giho.king_of_table_tennis.jwt.LoginFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final AuthenticationConfiguration authenticationConfiguration;
+  private final JWTUtil jwtUtil;
 
   @Bean
   public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -46,7 +48,7 @@ public class SecurityConfig {
         .requestMatchers("/admin").hasRole("ADMIN")
         .anyRequest().authenticated()
       )
-      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
+      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
       .sessionManagement((session) -> session // 세션 설정
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       );

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
@@ -1,0 +1,51 @@
+package com.giho.king_of_table_tennis.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+  private SecretKey secretKey;
+
+  public JWTUtil(@Value("${JWT_SECRET_KEY}") String secret) {
+    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public String getUserId(String token) {
+    return Jwts.parser()
+      .verifyWith(secretKey).build()
+      .parseSignedClaims(token).getPayload()
+      .get("id", String.class);
+  }
+
+  public String getRole(String token) {
+    return Jwts.parser()
+      .verifyWith(secretKey).build()
+      .parseSignedClaims(token).getPayload()
+      .get("role", String.class);
+  }
+
+  public boolean isExpired(String token) {
+    return Jwts.parser()
+      .verifyWith(secretKey).build()
+      .parseSignedClaims(token).getPayload()
+      .getExpiration().before(new Date());
+  }
+
+  public String createJwt(String id, String role, Long expiredMs) {
+    return Jwts.builder()
+      .claim("id", id)
+      .claim("role", role)
+      .issuedAt(new Date(System.currentTimeMillis()))
+      .expiration(new Date(System.currentTimeMillis() + expiredMs))
+      .signWith(secretKey)
+      .compact();
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
@@ -1,5 +1,6 @@
 package com.giho.king_of_table_tennis.jwt;
 
+import com.giho.king_of_table_tennis.dto.CustomUserDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,22 +9,32 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
   private final AuthenticationManager authenticationManager;
+  private final JWTUtil jwtUtil;
+
+  @Override
+  protected String obtainUsername(HttpServletRequest request) {
+    return request.getParameter("id"); // 기본인 username을 id로 바꿈
+  }
 
   @Override
   public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
     // 클라이언트 요청에서 username, password 추출
-    String username = obtainUsername(request);
+    String id = obtainUsername(request);
     String password = obtainPassword(request);
 
     // spring security에서 username과 password를 검증하기 위해 token에 담아야 함
-    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(id, password, null);
 
     // token에 담은 검증을 위한 AuthenticationManager로 전달
     return authenticationManager.authenticate(authToken);
@@ -32,12 +43,25 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
   // 로그인 성공 시 실행하는 메소드 (여기서 JWT 발급)
   @Override
   protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
-    System.out.println("로그인 성공");
+
+    CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+    String id = customUserDetails.getUsername(); // id를 가져옴
+
+    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+    Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+    GrantedAuthority auth = iterator.next();
+
+    String role = auth.getAuthority();
+
+    String token = jwtUtil.createJwt(id, role, 60*60*10L);
+
+    response.addHeader("Authorization", "Bearer " + token);
   }
 
   // 로그인 실패 시 실행하는 메소드
   @Override
   protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
-    System.out.println("로그인 실패");
+    response.setStatus(401);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/CustomUserDetailsService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/CustomUserDetailsService.java
@@ -16,9 +16,9 @@ public class CustomUserDetailsService implements UserDetailsService {
   private final UserRepository userRepository;
 
   @Override
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+  public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
 
-    UserEntity userEntity = userRepository.findById(username).orElse(null);
+    UserEntity userEntity = userRepository.findById(id).orElse(null);
 
     if (userEntity != null) {
       return new CustomUserDetails(userEntity);


### PR DESCRIPTION
## 개요
- JWTUtil 생성
- LoginFilter에서 obtainUsername 오버라이딩(id로)

## 작업 내용
- username 대신 id를 사용하고 있기 때문에 LoginFilter에서 UsernamePasswordAuthenticationFilter의 obtainUsername 메소드를 오버라이딩하여 request에서 파라미터에 username 대신 id를 사용할 수 있도록 수정함
- JWTUtil에서 JWT 토큰을 만들고 id와 role, 만료 여부를 확인하는 메소드 작성
- 로그인 요청에 대한 응답 메서드(successfulAuthentication, unsuccessfulAuthentication) 수정
  - 로그인 성공: JWT 토큰을 만들고 응답 헤더의 Authorization에 포함시켜 반환하게 함
  - 로그인 실패: HTTP 상태 코드를 401로 반환하게 함

## 테스트 방법
- Postman으로 'POST /login' 호출
- 요청 body에 id와 password 전달 시 DB에 사용자 확인 후 JWT 토큰을 만들고 헤더의 Authorization에 포함시켜 반환함
로그인 실패 시 HTTP 상태 코드를 401로 반환함