### PR TITLE
feature: JWTFilter를 만들어 LoginFilter 전에 배치하고, 토큰 유효성을 검사해 결과에 맞게 응답하도록 함

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
+++ b/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
@@ -14,6 +14,7 @@ public class KingOfTableTennisApplication {
 
     System.setProperty("MYSQL_PASSWORD", dotenv.get("MYSQL_PASSWORD"));
     System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
+    System.setProperty("TOKEN_EXP", dotenv.get("TOKEN_EXP"));
 
     SpringApplication.run(KingOfTableTennisApplication.class, args);
   }

--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.giho.king_of_table_tennis.config;
 
+import com.giho.king_of_table_tennis.jwt.JWTFilter;
 import com.giho.king_of_table_tennis.jwt.JWTUtil;
 import com.giho.king_of_table_tennis.jwt.LoginFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,6 +24,9 @@ public class SecurityConfig {
 
   private final AuthenticationConfiguration authenticationConfiguration;
   private final JWTUtil jwtUtil;
+
+  @Value("${TOKEN_EXP}")
+  private long tokenExp;
 
   @Bean
   public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -48,7 +53,8 @@ public class SecurityConfig {
         .requestMatchers("/admin").hasRole("ADMIN")
         .anyRequest().authenticated()
       )
-      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
+      .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
+      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, tokenExp), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
       .sessionManagement((session) -> session // 세션 설정
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       );

--- a/src/main/java/com/giho/king_of_table_tennis/controller/AdminController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AdminController.java
@@ -1,0 +1,15 @@
+package com.giho.king_of_table_tennis.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+public class AdminController {
+
+  @GetMapping("/admin")
+  public String adminP() {
+    return "admin controller";
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTFilter.java
@@ -1,0 +1,72 @@
+package com.giho.king_of_table_tennis.jwt;
+
+import com.giho.king_of_table_tennis.dto.CustomUserDetails;
+import com.giho.king_of_table_tennis.entity.UserEntity;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+  private final JWTUtil jwtUtil;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    // request에서 Authorization 헤더를 가져옴
+    String authorization = request.getHeader("Authorization");
+
+    // Authorization 헤더 검증
+    if (authorization == null || !authorization.startsWith("Bearer ")) {
+      System.out.println("token null");
+      filterChain.doFilter(request, response);
+
+      return;
+    }
+
+    // Bearer 부분 제거
+    String token = authorization.split(" ")[1];
+
+    // 토큰 만료 시간 검증
+    if (jwtUtil.isExpired(token)) {
+      System.out.println("token expired");
+      filterChain.doFilter(request, response);
+
+      return;
+    }
+
+    // 토큰에서 id와 role 획득
+    String id = jwtUtil.getUserId(token);
+    String role = jwtUtil.getRole(token);
+
+    // UserEntity 생성
+    UserEntity userEntity = new UserEntity();
+    userEntity.setId(id);
+    userEntity.setPassword("temp_password");
+    userEntity.setName("temp_name");
+    userEntity.setNickName("temp_nickName");
+    userEntity.setEmail("temp_email");
+    userEntity.setProfileImage("temp_profileImage");
+    userEntity.setRole(role);
+
+    // UserDetails에 UserEntity 객체 담기
+    CustomUserDetails customUserDetails = new CustomUserDetails(userEntity);
+
+    // spring security 인증 토큰 생성
+    Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+    // 세션에 사용자 등록
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
@@ -40,11 +40,14 @@ public class JWTUtil {
   }
 
   public String createJwt(String id, String role, Long expiredMs) {
+
+    Date now = new Date();
+
     return Jwts.builder()
       .claim("id", id)
       .claim("role", role)
-      .issuedAt(new Date(System.currentTimeMillis()))
-      .expiration(new Date(System.currentTimeMillis() + expiredMs))
+      .issuedAt(now)
+      .expiration(new Date(now.getTime() + expiredMs))
       .signWith(secretKey)
       .compact();
   }

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -20,6 +21,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
   private final AuthenticationManager authenticationManager;
   private final JWTUtil jwtUtil;
+  private final long tokenExp;
 
   @Override
   protected String obtainUsername(HttpServletRequest request) {
@@ -54,7 +56,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     String role = auth.getAuthority();
 
-    String token = jwtUtil.createJwt(id, role, 60*60*10L);
+    String token = jwtUtil.createJwt(id, role, tokenExp);
 
     response.addHeader("Authorization", "Bearer " + token);
   }


### PR DESCRIPTION
## 개요
- JWTFilter 생성
- .env에서 토큰 유효시간을 하루로 설정

## 작업 내용
- JWTFilter를 LoginFilter 이전에 배치하여 토큰 유효성에 따라 응답하도록 함
- .env에서 토큰 유효시간을 하루로 설정하고 Value 어노테이션을 통해 SecurityConfig -> LoginFilter로 넘겨줌(로그인을 성공했을 때 토큰의 유효시간을 넘겨주고 만들어야 하기 때문)
- adminController를 만들어 role에 "ROLE_ADMIN"을 갖고 있고, JWT 토큰이 있으면 접근할 수 있게 함

## JWTFilter 적용 후 요청 시 동작 흐름
1. /login 요청일 경우
- JWTFilter가 실행됨
  - Authorization 헤더가 없거나, 잘못된 경우 doFilterChain()을 호출해 그냥 다음 필터로 진행
- 이어서 LoginFilter가 실행됨
  - 폼 데이터로 전달된 id와 password를 사용해 인증 시도
  - 성공 시 JWT 발급 후 Authorization 헤더에 포함하여 응답
 
2. /api/**과 같이 인증이 필요한 요청의 경우
- JWTFilter가 실행됨
  - Authorization 헤더가 있고 유효하면 SecurityContextHolder에 사용자 등록
  - Authorization 헤더가 없거나 유효하지 않으면 그냥 doFilter() 실행하고 그 후, Spring Security에서 인증 실패 처리
- 이 경우에는 LoginFilter는 실행되지 않음(/login 요청에서만 작동) 

## 테스트 방법
Postman으로 'POST /login' 호출
요청 body에 id와 password 전달 시 DB에 사용자 확인 후 JWT 토큰을 만들고 헤더의 Authorization에 포함시켜 반환함
반환 받은 JWT 토큰을 포함시켜 'GET /admin' 호출
role에 "ROLE_ADMIN"을 갖고 있고, JWT 토큰이 유효하면 "admin controller"가 반환됨