### PR TITLE
accessToken과 refreshToken을 둘 다 만들고 반환하도록 함 / 토큰의 claim에 category를 추가해 구분

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
+++ b/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
@@ -14,7 +14,8 @@ public class KingOfTableTennisApplication {
 
     System.setProperty("MYSQL_PASSWORD", dotenv.get("MYSQL_PASSWORD"));
     System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
-    System.setProperty("TOKEN_EXP", dotenv.get("TOKEN_EXP"));
+    System.setProperty("ACCESS_TOKEN_EXP", dotenv.get("ACCESS_TOKEN_EXP"));
+    System.setProperty("REFRESH_TOKEN_EXP", dotenv.get("REFRESH_TOKEN_EXP"));
 
     SpringApplication.run(KingOfTableTennisApplication.class, args);
   }

--- a/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
+++ b/src/main/java/com/giho/king_of_table_tennis/config/SecurityConfig.java
@@ -25,8 +25,11 @@ public class SecurityConfig {
   private final AuthenticationConfiguration authenticationConfiguration;
   private final JWTUtil jwtUtil;
 
-  @Value("${TOKEN_EXP}")
-  private long tokenExp;
+  @Value("${ACCESS_TOKEN_EXP}")
+  private long accessTokenExp;
+
+  @Value("${REFRESH_TOKEN_EXP}")
+  private long refreshTokenExp;
 
   @Bean
   public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -54,7 +57,7 @@ public class SecurityConfig {
         .anyRequest().authenticated()
       )
       .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
-      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, tokenExp), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
+      .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, accessTokenExp, refreshTokenExp), UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter를 custom한 LoginFilter()로 대체
       .sessionManagement((session) -> session // 세션 설정
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       );

--- a/src/main/java/com/giho/king_of_table_tennis/controller/AdminController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.giho.king_of_table_tennis.controller;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -10,6 +12,9 @@ public class AdminController {
 
   @GetMapping("/admin")
   public String adminP() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String id = authentication.getName();
+    System.out.println("id: " + id);
     return "admin controller";
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/dto/LoginDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/LoginDTO.java
@@ -1,0 +1,11 @@
+package com.giho.king_of_table_tennis.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginDTO {
+  private String id;
+  private String password;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
@@ -18,6 +18,13 @@ public class JWTUtil {
     this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
   }
 
+  public String getCategory(String token) {
+    return Jwts.parser()
+      .verifyWith(secretKey).build()
+      .parseSignedClaims(token).getPayload()
+      .get("category", String.class);
+  }
+
   public String getUserId(String token) {
     return Jwts.parser()
       .verifyWith(secretKey).build()
@@ -39,11 +46,12 @@ public class JWTUtil {
       .getExpiration().before(new Date());
   }
 
-  public String createJwt(String id, String role, Long expiredMs) {
+  public String createJwt(String category, String id, String role, Long expiredMs) {
 
     Date now = new Date();
 
     return Jwts.builder()
+      .claim("category", category)
       .claim("id", id)
       .claim("role", role)
       .issuedAt(now)


### PR DESCRIPTION
## 📌 개요
- refreshToken도 만들어서 로그인 시 accessToken과 반환
- adminController에서 Spring Security 인증 객체 사용해 id 가져오는 거 해봄

---

## ✅ 작업 내용
- loginFilter에서 로그인 성공 시 refreshToken(7일)도 만들어서 accessToken(1일)과 같이 반환함
- 토큰을 만들 때 claim에 category를 추가해 두 토큰을 구분하도록 함
- ObjectMapper를 사용해 요청과 응답을 JSON으로 할 수 있게 코드 수정함
  - 요청을 할 때 body에 id와 password를 입력
  - 응답에는 body에 accessToken과 refreshToken 포함
- adminController에서 Spring Security 인증 객체를 사용해 id를 출력하도록 함

```jsonc
요청 body
{
  "id": "id value",
  "password": "password value"
}

응답 body
{
  "accessToken": "accessToken value",
  "refreshToken": "refreshToken value"
}
```

---

## 🔍 테스트 방법
- Postman으로 'POST /login' 호출(body에 위의 json 형태로 담아야함)
- 요청 body에 id와 password 전달 시 DB에 사용자 확인 후 JWT 토큰을 만들고 body에 accessToken과 refreshToken을 위의 응답 body와 같이 반환함