### PR TITLE
feature: 에러 상황에 대한 CustomException을 만들어 상황에 맞는 Exception을 발생시킴 / 이전 커밋 잘못된 부분 수정

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
@@ -4,12 +4,11 @@ import com.giho.king_of_table_tennis.dto.RegisterDTO;
 import com.giho.king_of_table_tennis.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {

--- a/src/main/java/com/giho/king_of_table_tennis/exception/CustomException.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/CustomException.java
@@ -1,0 +1,20 @@
+package com.giho.king_of_table_tennis.exception;
+
+public class CustomException extends RuntimeException{
+
+  private final ErrorCode errorCode;
+
+ public CustomException(ErrorCode errorCode) {
+   super(errorCode.getMessage());
+   this.errorCode = errorCode;
+ }
+
+ public CustomException(ErrorCode errorCode, String message) {
+   super(message);
+   this.errorCode = errorCode;
+ }
+
+ public ErrorCode getErrorCode() {
+   return errorCode;
+ }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.giho.king_of_table_tennis.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+  // 사용자
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+  USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+
+  // 일반
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/exception/ErrorResponse.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.giho.king_of_table_tennis.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ErrorResponse {
+
+  private final String code;
+  private final String message;
+  private final LocalDateTime timestamp;
+  private final String path;
+
+}

--- a/src/main/java/com/giho/king_of_table_tennis/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.giho.king_of_table_tennis.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.LocalDateTime;
+
+public class GlobalExceptionHandler {
+
+  // CustomException 처리
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+    ErrorCode errorCode = e.getErrorCode();
+    ErrorResponse response = new ErrorResponse(
+      errorCode.name(),
+      errorCode.getMessage(),
+      LocalDateTime.now(),
+      request.getRequestURI()
+    );
+    return ResponseEntity.status(errorCode.getStatus()).body(response);
+  }
+
+  //
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleUnhandledException(Exception e, HttpServletRequest request) {
+    ErrorResponse response = new ErrorResponse(
+      ErrorCode.INTERNAL_SERVER_ERROR.name(),
+      e.getMessage(),
+      LocalDateTime.now(),
+      request.getRequestURI()
+    );
+    return ResponseEntity.status(500).body(response);
+  }
+
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTFilter.java
@@ -2,6 +2,8 @@ package com.giho.king_of_table_tennis.jwt;
 
 import com.giho.king_of_table_tennis.dto.CustomUserDetails;
 import com.giho.king_of_table_tennis.entity.UserEntity;
+import com.giho.king_of_table_tennis.exception.CustomException;
+import com.giho.king_of_table_tennis.exception.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/LoginFilter.java
@@ -82,7 +82,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     String role = auth.getAuthority();
 
     String accessToken = jwtUtil.createJwt("access", id, role, accessTokenExp);
-    String refreshToken = jwtUtil.createJwt("refresh", id, role, accessTokenExp);
+    String refreshToken = jwtUtil.createJwt("refresh", id, role, refreshTokenExp);
 
     // JSON 응답
     response.setContentType("application/json");

--- a/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
@@ -2,6 +2,8 @@ package com.giho.king_of_table_tennis.service;
 
 import com.giho.king_of_table_tennis.dto.RegisterDTO;
 import com.giho.king_of_table_tennis.entity.UserEntity;
+import com.giho.king_of_table_tennis.exception.CustomException;
+import com.giho.king_of_table_tennis.exception.ErrorCode;
 import com.giho.king_of_table_tennis.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,7 +21,7 @@ public class AuthService {
     boolean isExistUser = userRepository.existsById(registerDTO.getId());
 
     if (isExistUser) {
-      return false;
+      throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
     }
 
     UserEntity userEntity = new UserEntity();


### PR DESCRIPTION
## 📌 개요
- CustomException을 만들어 에러 상황에 대해 적절한 에러 코드를 발생시킴
- refreshToken 만료시간을 accessTokenExp로 잘못 작성한 것 수정

---

## ✅ 작업 내용
- exception 패키지 추가
  - CustomException: RuntimeException을 상속받아 애플리케이션 내에서 특정 예외 상황을 명확히 표현
  - ErrorCode: 예외 상황에 대한 코드와 메시지를 Enum으로 정의
  - ErrorResponse: 예외 발생 시 클라이언트에게 전달할 응답 형식 정의
  - GlobalExceptionHandler: Exception 발생 시 공통된 ErrorResponse 형태로 응답하게 함

- LoginFilter에서 refreshToken을 만들 때 accessTokenExp를 넘기던 것을 refreshTokenExp로 넘기게 수정

---

## 🔍 테스트 방법
- throw new CustomException(...)이 발생하는 구간에서 로그 확인
  - 현재는 'POST /api/auth/register'에서 중복된 사용자 정보를 입력해 회원가입을 하려는 경우 발생

``` bash
com.giho.king_of_table_tennis.exception.CustomException: 이미 존재하는 사용자입니다.
```

## 📋 다음에 할 것
- GlobalExceptionHandler에서 @RestControllerAdvice 어노테이션 추가
  - 해당 어노테이션이 누락되어 로그에서만 위와 같이(테스트 방법의 코드 블럭) 나오고 응답은 이전과 같은 결과를 반환하고 있다.