### PR TITLE
Feature/jwt: 구글 SMTP를 사용한 이메일 전송(인증번호)과 인증번호 확인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,15 @@ dependencies {
 
     // Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // 이메일 발송을 위한 Spring Boot Starter Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // HTML 템플릿을 사용하여 이메일을 꾸미기 위한 Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // Google API Client Library for Java
+    implementation 'com.google.api-client:google-api-client:2.7.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
+++ b/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
@@ -16,6 +16,7 @@ public class KingOfTableTennisApplication {
     System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
     System.setProperty("ACCESS_TOKEN_EXP", dotenv.get("ACCESS_TOKEN_EXP"));
     System.setProperty("REFRESH_TOKEN_EXP", dotenv.get("REFRESH_TOKEN_EXP"));
+    System.setProperty("GOOGLE_MAIL_PASSWORD", dotenv.get("GOOGLE_MAIL_PASSWORD"));
 
     SpringApplication.run(KingOfTableTennisApplication.class, args);
   }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
@@ -19,4 +19,14 @@ public class EmailController {
     SendVerificationCodeResponse sendVerificationCodeResponse = emailService.sendVerificationEmail(type, email, request);
     return ResponseEntity.ok(sendVerificationCodeResponse);
   }
+
+  @GetMapping("/code/verify/{code}")
+  public ResponseEntity<String> checkVerificationCode(@RequestHeader("sessionId") String sessionId, @PathVariable String code, HttpServletRequest request) {
+    boolean response = emailService.checkVerificationCode(sessionId, code, request);
+    if (response) {
+      return ResponseEntity.ok("인증번호가 일치합니다.");
+    } else {
+      return ResponseEntity.ok("인증번호가 일치하지 않습니다.");
+    }
+  }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
@@ -1,0 +1,22 @@
+package com.giho.king_of_table_tennis.controller;
+
+import com.giho.king_of_table_tennis.dto.SendVerificationCodeResponse;
+import com.giho.king_of_table_tennis.service.EmailService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/email")
+public class EmailController {
+
+  private final EmailService emailService;
+
+  @GetMapping("/code/{type}/{email}")
+  public ResponseEntity<SendVerificationCodeResponse> sendVerificationCode(@PathVariable String type, @PathVariable String email, HttpServletRequest request) {
+    SendVerificationCodeResponse sendVerificationCodeResponse = emailService.sendVerificationEmail(type, email, request);
+    return ResponseEntity.ok(sendVerificationCodeResponse);
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/SendVerificationCodeResponse.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/SendVerificationCodeResponse.java
@@ -1,0 +1,12 @@
+package com.giho.king_of_table_tennis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SendVerificationCodeResponse {
+  private String sessionId;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
@@ -12,6 +12,11 @@ public enum ErrorCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
   USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
 
+  // 인증번호 / 이메일
+  VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+  INVALID_SESSION(HttpStatus.BAD_REQUEST, "세션이 유효하지 않습니다."),
+  EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호 전송 중 오류가 발생했습니다."),
+
   // 일반
   BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
@@ -1,0 +1,94 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.SendVerificationCodeResponse;
+import com.giho.king_of_table_tennis.exception.CustomException;
+import com.giho.king_of_table_tennis.exception.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@RequiredArgsConstructor
+@Service
+public class EmailService {
+
+  private final JavaMailSender javaMailSender;
+
+  private final SpringTemplateEngine templateEngine;
+
+  // 이메일 전송 메서드
+  public SendVerificationCodeResponse sendVerificationEmail (String type, String email, HttpServletRequest request) {
+    try {
+      HttpSession session = request.getSession(true);
+      MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+      String verificationCode = generateVerificationCode();
+
+      mimeMessageHelper.setTo(email); // 수신자 설정
+      mimeMessageHelper.setSubject(getSubjectByType(type)); // 이메일 제목 설정
+      mimeMessageHelper.setText(buildEmailContent(verificationCode, type), true); // 이메일 내용, HTML 형식으로 설정
+
+      // 이메일 발송
+      javaMailSender.send(mimeMessage);
+
+      // 세션에 인증번호 저장
+      boolean isSaveCode = saveCodeToSession(verificationCode, 3, session);
+
+      if (!isSaveCode) {
+        throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
+      }
+      return new SendVerificationCodeResponse(session.getId());
+    } catch (MessagingException messagingException) {
+      throw new CustomException(ErrorCode.EMAIL_SEND_FAILED, "이메일 전송 실패: " + messagingException.getMessage());
+    } catch (Exception e) {
+      throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  // 이메일 타입에 맞는 제목 반환
+  private String getSubjectByType(String type) {
+    return switch (type) {
+      case "register" -> "[탁구왕] 회원가입 인증번호";
+      default -> "[탁구왕] 이메일";
+    };
+  }
+
+  // 이메일 내용 구성 (HTML)
+  private String buildEmailContent(String code, String type) {
+    Context context = new Context();
+    context.setVariable("code", code);
+    return templateEngine.process(getTemplateName(type), context); // 적합한 템플릿 반환
+  }
+
+  // 이메일 타입에 맞는 템플릿 이름 반환
+  private String getTemplateName(String type) {
+    return switch (type) {
+      case "register" -> "sendCode_register"; // 회원가입 템플릿
+      default -> "sendCode_default"; // 기본 템플릿
+    };
+  }
+
+  // 6자리 인증번호 생성하는 메서드
+  private String generateVerificationCode() {
+    return String.format("%06d", (int)(Math.random() * 900000) + 100000); // 1000 ~ 9999 사이의 6자리 인증번호 생성
+  }
+
+  // 인증번호를 세션에 저장하는 메서드
+  private boolean saveCodeToSession(String verificationCode, int expirationTime, HttpSession session) {
+    try {
+      session.setAttribute("verificationCode", verificationCode);
+      session.setMaxInactiveInterval(expirationTime * 60); // 3분
+
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
@@ -52,6 +52,27 @@ public class EmailService {
     }
   }
 
+  // 인증번호 확인 메서드
+  public boolean checkVerificationCode(String sessionId, String userCode, HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    if (session == null || !sessionId.equals(session.getId())) {
+      throw new CustomException(ErrorCode.INVALID_SESSION);
+    }
+
+    String sessionCode = (String) session.getAttribute("verificationCode");
+
+    if (sessionCode == null) {
+      throw new CustomException(ErrorCode.VERIFICATION_CODE_MISMATCH, "저장된 인증번호가 없습니다.");
+    }
+
+    if (!sessionCode.equals(userCode)) {
+      throw new CustomException(ErrorCode.VERIFICATION_CODE_MISMATCH);
+    }
+
+    session.removeAttribute("verificationCode");
+    return true;
+  }
+
   // 이메일 타입에 맞는 제목 반환
   private String getSubjectByType(String type) {
     return switch (type) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,18 @@ spring:
       hibernate:
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: dlrlghproject0429@gmail.com
+    password: ${GOOGLE_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 server:
   address: 0.0.0.0
   port: 8080

--- a/src/main/resources/templates/sendCode_register.html
+++ b/src/main/resources/templates/sendCode_register.html
@@ -1,0 +1,20 @@
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+  <h1> 탁구왕 </h1>
+  <br>
+  <p> 회원가입 화면으로 돌아가서 인증번호를 입력해주세요.</p>
+  <br>
+
+  <div align="center" style="border:1px solid black; font-family:verdana;">
+    <br>
+    <h3 style="color:blue"> 회원가입 인증번호 입니다. </h3>
+    <div style="font-size:130%" th:text="${code}"> </div>
+    <br>
+  </div>
+  <br/>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 📌 개요
- 이메일로 인증코드 보내는 api 생성
- 인증코드 6자리 확인하는 api 생성

---

## ✅ 작업 내용
- 구글 SMTP를 사용해 회원가입 시 필요한 인증번호 6자리 전송
  - 세션에 3분 동안 저장
- 세션에 저장된 인증번호와 사용자가 입력한 인증번호를 비교하여 결과 반환
  - 3분이 지나면 세션에서 사라짐
  - 3분 안에 입력하여 인증번호가 일치하면 세션이 사라져 다시 같은 인증번호로 확인하지 못하게 함

---

## 🔍 테스트 방법
- Postman으로 'GET /api/auth/email/code/register/{email}' 호출
```jsonc
응답형식(JSON)

{
    "sessionId": "C9D663E9839884111CC7CB0DF1C82177"
}
```


- Postman으로 'GET /api/auth/email/code/verify/{code}' 호출
  - 인증코드 보내고 응답받은 세션 ID를 요청의 headers에 추가 / sessionId: {C9D663E9839884111CC7CB0DF1C82177}
```jsonc
응답

"인증번호가 일치합니다."
or
"인증번호가 일치하지 않습니다."
```