### PR TITLE
Feature/jwt: 아이디/비밀번호 찾기 API 생성, 그 외 수정사항

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.giho.king_of_table_tennis.controller;
 
 import com.giho.king_of_table_tennis.dto.CheckExistsResponse;
+import com.giho.king_of_table_tennis.dto.FindIdResponse;
 import com.giho.king_of_table_tennis.dto.RegisterDTO;
 import com.giho.king_of_table_tennis.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,11 @@ public class AuthController {
 
     CheckExistsResponse checkExistsResponse = authService.checkNickNameDuplication(nickName);
     return ResponseEntity.ok(checkExistsResponse);
+  }
+
+  @GetMapping("/id")
+  public ResponseEntity<FindIdResponse> findId(@RequestParam(name = "name") String name, @RequestParam(name = "email") String email) {
+    FindIdResponse findIdResponse = authService.findId(name, email);
+    return ResponseEntity.ok(findIdResponse);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.giho.king_of_table_tennis.controller;
 
+import com.giho.king_of_table_tennis.dto.ChangePasswordRequest;
 import com.giho.king_of_table_tennis.dto.CheckExistsResponse;
 import com.giho.king_of_table_tennis.dto.FindIdResponse;
 import com.giho.king_of_table_tennis.dto.RegisterDTO;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Auth-Controller", description = "회원가입, 아이디/닉네임 중복 체크 API 엔드포인트")
+@Tag(name = "Auth-Controller", description = "회원가입, 아이디/닉네임 중복 체크 API")
 @RequestMapping("/api/auth")
 public class AuthController {
 
@@ -26,7 +27,7 @@ public class AuthController {
     responseCode = "200",
     description = "회원가입 성공 여부 반환",
     content = @Content(
-      mediaType = "application/json",
+      mediaType = "text/plain",
       schema = @Schema(type = "string", example = "회원가입에 성공/실패했습니다.")
     )
   )
@@ -43,7 +44,7 @@ public class AuthController {
 
   }
 
-  @Operation(summary = "ID 중복 확인", description = "회원가입 시 사용하려는 ID의 중복 여부를 확인합니다.")
+  @Operation(summary = "ID 중복 확인", description = "회원가입 시 사용하려는 ID의 중복 여부를 확인하는 API")
   @ApiResponse(
     responseCode = "200",
     description = "ID 중복 여부 반환",
@@ -59,7 +60,7 @@ public class AuthController {
     return ResponseEntity.ok(checkExistsResponse);
   }
 
-  @Operation(summary = "nickName 중복 확인", description = "회원가입 시 사용하려는 nickName의 중복 여부를 확인합니다.")
+  @Operation(summary = "nickName 중복 확인", description = "회원가입 시 사용하려는 nickName의 중복 여부를 확인하는 API")
   @ApiResponse(
     responseCode = "200",
     description = "nickName 중복 여부 반환",
@@ -75,9 +76,37 @@ public class AuthController {
     return ResponseEntity.ok(checkExistsResponse);
   }
 
+  @Operation(summary = "id 찾기", description = "이름과 이메일을 통해 아이디를 찾고 반환해주는 API")
+  @ApiResponse(
+    responseCode = "200",
+    description = "아이디 확인 후 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = FindIdResponse.class)
+    )
+  )
   @GetMapping("/id")
   public ResponseEntity<FindIdResponse> findId(@RequestParam(name = "name") String name, @RequestParam(name = "email") String email) {
     FindIdResponse findIdResponse = authService.findId(name, email);
     return ResponseEntity.ok(findIdResponse);
+  }
+
+  @Operation(summary = "비밀번호 찾기(변경)", description = "아이디와 이름, 이메일로 비밀번호 변경할 수 있는 API")
+  @ApiResponse(
+    responseCode = "200",
+    description = "아이디와 이름, 이메일로 확인 후 비밀번호 변경",
+    content = @Content(
+      mediaType = "text/plain",
+      schema = @Schema(type = "string", example = "비밀번호가 변경되었습니다.(변경되지 않았습니다.)")
+    )
+  )
+  @PatchMapping("/password")
+  public ResponseEntity<String> changePassword(@RequestBody ChangePasswordRequest changePasswordRequest) {
+    boolean response = authService.findPassword(changePasswordRequest);
+    if (response) {
+      return ResponseEntity.ok("비밀번호가 변경되었습니다.");
+    } else {
+      return ResponseEntity.ok("비밀번호가 변경되지 않았습니다.");
+    }
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
@@ -2,6 +2,11 @@ package com.giho.king_of_table_tennis.controller;
 
 import com.giho.king_of_table_tennis.dto.SendVerificationCodeResponse;
 import com.giho.king_of_table_tennis.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,17 +14,44 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Email-Controller", description = "인증번호 전송, 인증번호 확인 API 엔드포인트")
 @RequestMapping("/api/auth/email")
 public class EmailController {
 
   private final EmailService emailService;
 
+  @Operation(
+    summary = "인증번호 전송",
+    description =
+      "<h1>인증번호 전송 API</h1>" +
+      "<h2>type</h2>" +
+      "<ul>" +
+        "<li>회원가입: register</li>" +
+      "</ul>"
+  )
+  @ApiResponse(
+    responseCode = "200",
+    description = "인증번호가 저장되어 있는 세션 ID 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = SendVerificationCodeResponse.class)
+    )
+  )
   @GetMapping("/code/{type}/{email}")
   public ResponseEntity<SendVerificationCodeResponse> sendVerificationCode(@PathVariable String type, @PathVariable String email, HttpServletRequest request) {
     SendVerificationCodeResponse sendVerificationCodeResponse = emailService.sendVerificationEmail(type, email, request);
     return ResponseEntity.ok(sendVerificationCodeResponse);
   }
 
+  @Operation(summary = "인증번호 확인", description = "인증번호 확인 API")
+  @ApiResponse(
+    responseCode = "200",
+    description = "사용자가 입력한 인증번호와 세션에 저장된 인증번호를 확인 후 결과 반환",
+    content = @Content(
+      mediaType = "text/plain",
+      schema = @Schema(type = "string", example = "인증번호가 일치합니다.(일치하지 않습니다.)")
+    )
+  )
   @GetMapping("/code/verify/{code}")
   public ResponseEntity<String> checkVerificationCode(@RequestHeader("sessionId") String sessionId, @PathVariable String code, HttpServletRequest request) {
     boolean response = emailService.checkVerificationCode(sessionId, code, request);

--- a/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/EmailController.java
@@ -37,8 +37,8 @@ public class EmailController {
       schema = @Schema(implementation = SendVerificationCodeResponse.class)
     )
   )
-  @GetMapping("/code/{type}/{email}")
-  public ResponseEntity<SendVerificationCodeResponse> sendVerificationCode(@PathVariable String type, @PathVariable String email, HttpServletRequest request) {
+  @GetMapping("/code/{type}")
+  public ResponseEntity<SendVerificationCodeResponse> sendVerificationCode(@PathVariable String type, @RequestParam("email") String email, HttpServletRequest request) {
     SendVerificationCodeResponse sendVerificationCodeResponse = emailService.sendVerificationEmail(type, email, request);
     return ResponseEntity.ok(sendVerificationCodeResponse);
   }
@@ -52,8 +52,8 @@ public class EmailController {
       schema = @Schema(type = "string", example = "인증번호가 일치합니다.(일치하지 않습니다.)")
     )
   )
-  @GetMapping("/code/verify/{code}")
-  public ResponseEntity<String> checkVerificationCode(@RequestHeader("sessionId") String sessionId, @PathVariable String code, HttpServletRequest request) {
+  @GetMapping("/code/verify")
+  public ResponseEntity<String> checkVerificationCode(@RequestHeader("sessionId") String sessionId, @RequestParam("code") String code, HttpServletRequest request) {
     boolean response = emailService.checkVerificationCode(sessionId, code, request);
     if (response) {
       return ResponseEntity.ok("인증번호가 일치합니다.");

--- a/src/main/java/com/giho/king_of_table_tennis/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/ChangePasswordRequest.java
@@ -1,14 +1,15 @@
 package com.giho.king_of_table_tennis.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
-public class FindIdResponse {
-  @Schema(description = "찾은 아이디", example = "asdfasdf")
+@Schema(description = "비밀번호 찾기(변경) DTO")
+public class ChangePasswordRequest {
   private String id;
+  private String password;
+  private String name;
+  private String email;
 }

--- a/src/main/java/com/giho/king_of_table_tennis/dto/FindIdResponse.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/FindIdResponse.java
@@ -1,0 +1,12 @@
+package com.giho.king_of_table_tennis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FindIdResponse {
+  private String id;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/SendVerificationCodeResponse.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/SendVerificationCodeResponse.java
@@ -1,5 +1,6 @@
 package com.giho.king_of_table_tennis.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,5 +9,6 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class SendVerificationCodeResponse {
+  @Schema(description = "세션 아이디", example = "C9D663E9839884111CC7CB0DF1C82177")
   private String sessionId;
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
@@ -3,9 +3,13 @@ package com.giho.king_of_table_tennis.repository;
 import com.giho.king_of_table_tennis.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, String> {
 
   boolean existsById(String id);
 
   boolean existsByNickName(String nickName);
+
+  Optional<UserEntity> findByNameAndEmail(String name, String email);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity, String> {
   boolean existsByNickName(String nickName);
 
   Optional<UserEntity> findByNameAndEmail(String name, String email);
+
+  Optional<UserEntity> findByIdAndNameAndEmail(String id, String name, String email);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.giho.king_of_table_tennis.service;
 
+import com.giho.king_of_table_tennis.dto.ChangePasswordRequest;
 import com.giho.king_of_table_tennis.dto.CheckExistsResponse;
 import com.giho.king_of_table_tennis.dto.FindIdResponse;
 import com.giho.king_of_table_tennis.dto.RegisterDTO;
@@ -57,5 +58,19 @@ public class AuthService {
     UserEntity user = userRepository.findByNameAndEmail(name, email)
       .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     return new FindIdResponse(user.getId());
+  }
+
+  public boolean findPassword(ChangePasswordRequest changePasswordRequest) {
+    try {
+      UserEntity user = userRepository.findByIdAndNameAndEmail(changePasswordRequest.getId(), changePasswordRequest.getName(), changePasswordRequest.getEmail())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+      user.setPassword(bCryptPasswordEncoder.encode(changePasswordRequest.getPassword()));
+      userRepository.save(user);
+      return true;
+    } catch (Exception e) {
+      System.out.println("Error: " + e.getMessage());
+      return false;
+    }
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.giho.king_of_table_tennis.service;
 
 import com.giho.king_of_table_tennis.dto.CheckExistsResponse;
+import com.giho.king_of_table_tennis.dto.FindIdResponse;
 import com.giho.king_of_table_tennis.dto.RegisterDTO;
 import com.giho.king_of_table_tennis.entity.UserEntity;
 import com.giho.king_of_table_tennis.exception.CustomException;
@@ -50,5 +51,11 @@ public class AuthService {
 
     boolean isDuplication = userRepository.existsByNickName(nickName);
     return new CheckExistsResponse(isDuplication);
+  }
+
+  public FindIdResponse findId(String name, String email) {
+    UserEntity user = userRepository.findByNameAndEmail(name, email)
+      .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    return new FindIdResponse(user.getId());
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/EmailService.java
@@ -77,6 +77,8 @@ public class EmailService {
   private String getSubjectByType(String type) {
     return switch (type) {
       case "register" -> "[탁구왕] 회원가입 인증번호";
+      case "find-id" -> "[탁구왕] 아이디 찾기 인증번호";
+      case "find-password" -> "[탁구왕] 비밀번호 찾기 인증번호";
       default -> "[탁구왕] 이메일";
     };
   }
@@ -92,6 +94,8 @@ public class EmailService {
   private String getTemplateName(String type) {
     return switch (type) {
       case "register" -> "sendCode_register"; // 회원가입 템플릿
+      case "find-id" -> "sendCode_findId"; // 아이디 찾기 템플릿
+      case "find-password" -> "sendCode_findPassword"; // 비밀번호 찾기 템플릿
       default -> "sendCode_default"; // 기본 템플릿
     };
   }

--- a/src/main/resources/templates/sendCode_findId.html
+++ b/src/main/resources/templates/sendCode_findId.html
@@ -1,0 +1,20 @@
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+  <h1> 탁구왕 </h1>
+  <br>
+  <p> 아이디 찾기로 돌아가서 인증번호를 입력해주세요.</p>
+  <br>
+
+  <div align="center" style="border:1px solid black; font-family:verdana;">
+    <br>
+    <h3 style="color:blue"> 아이디 찾기 인증번호 입니다. </h3>
+    <div style="font-size:130%" th:text="${code}"> </div>
+    <br>
+  </div>
+  <br/>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/sendCode_findPassword.html
+++ b/src/main/resources/templates/sendCode_findPassword.html
@@ -1,0 +1,20 @@
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+  <h1> 탁구왕 </h1>
+  <br>
+  <p> 비밀번호 찾기로 돌아가서 인증번호를 입력해주세요.</p>
+  <br>
+
+  <div align="center" style="border:1px solid black; font-family:verdana;">
+    <br>
+    <h3 style="color:blue"> 비밀번호 찾기 인증번호 입니다. </h3>
+    <div style="font-size:130%" th:text="${code}"> </div>
+    <br>
+  </div>
+  <br/>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 📌 개요
- EmailController의 API에 swagger 적용
- EmailController에서 이메일과 인증번호를 PathVariable가 아닌 RequestParam으로 받도록 수정
- 아이디 찾기 api 구현
- 비밀번호 찾기 api 구현
- 아이디/비밀번호 찾기에서 사용할 이메일 템플릿 생성

---

## ✅ 작업 내용
- 이전 작업에서 만든 EmailController의 API에 swagger 코드 작성
- EmailController에서 이메일과 인증번호를 PathVariable가 아닌 RequestParam으로 받도록 수정
  - 요청에서 이메일과 인증번호를 숨기기 위해 RequestParam으로 변경
- 이름과 이메일로 아이디 찾는 api 구현
  - 프론트 흐름: 이름과 이메일 작성 후 이메일 인증 -> 다음 화면에서 사용자 아이디 보여줌
- 이름과 아이디, 이메일로 비밀번호 찾기(변경) api 구현 / 비밀번호는 변경하는 것이지만 통일성을 위해 찾기로 작성함
  - 프론트 흐름: 이름과 아이디, 이메일 작성 후 이메일 인증 -> 다음 화면에서 새로운 비밀번호 작성 후 변경
- 아이디, 비밀번호 찾기에 사용할 이메일 템플릿 생성
  - 이메일 보내는 타입에 따라 템플릿의 제목과 내용을 구분짓기 위해 템플릿을 새로 추가함

---

## 🔍 테스트 방법
- Swagger UI와 PostMan으로 가능
  - http://localhost:8080/swagger-ui.html

- 이메일로 인증코드 전송하는 api
  - Postman으로 'GET /api/auth/email/code/{type}?email={email}' 호출 (중괄호는 실제 값이 들어가야 하는 부분)
    - 회원가입: register
    - 아이디 찾기: find-id
    - 비밀번호 찾기: find-password
  - 응답 형식은 이전과 동일
- 인증코드 확인하는 api 
  - Postman으로 'GET /api/auth/email/code/verify?code={code}' 호출 (중괄호는 실제 값이 들어가야 하는 부분)
    - 인증코드 보내고 응답받은 세션 ID를 요청의 headers에 추가 / sessionId: {C9D663E9839884111CC7CB0DF1C82177}
  - 응답 형식은 이전과 동일
- 아이디 찾기 api
  - Postman으로 'GET /api/auth/id?name={name}&email={email}' 호출
```jsonc
응답형식(JSON)
{
    "id": "asdfasdf"
}
```
- 비밀번호 찾기 api
  - Postman으로 'PATCH /api/auth/password' 호출
    - 요청 body에 raw/JSON으로 값 전달
```jsonc
body 예시
{
    "id": "asdfasdf",
    "password": "asdf1234!",
    "name": "giho",
    "email": "ff6022@naver.com"
}
```

```jsonc
응답형식(TEXT)
"비밀번호가 변경되었습니다."
or
"비밀번호가 변경되지 않았습니다."
```