### PR TITLE
Feature/jwt: refreshToken으로 accessToken 재발급 받는 API 구현

### DIFF
--- a/src/main/java/com/giho/king_of_table_tennis/controller/UserController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/UserController.java
@@ -1,9 +1,7 @@
 package com.giho.king_of_table_tennis.controller;
 
-import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
-import com.giho.king_of_table_tennis.dto.CheckExistsResponseDTO;
-import com.giho.king_of_table_tennis.dto.ProfileRegistrationRequestDTO;
-import com.giho.king_of_table_tennis.dto.TableTennisInfoRegistrationRequestDTO;
+import com.giho.king_of_table_tennis.dto.*;
+import com.giho.king_of_table_tennis.service.TokenService;
 import com.giho.king_of_table_tennis.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
 
   private final UserService userService;
+
+  private final TokenService tokenService;
 
   @Operation(summary = "nickName 중복 확인", description = "회원가입 시 사용하려는 nickName의 중복 여부를 확인하는 API", security = @SecurityRequirement(name = "JWT"))
   @ApiResponse(
@@ -68,6 +67,21 @@ public class UserController {
   @PostMapping("/tableTennisInfo")
   public ResponseEntity<BooleanResponseDTO> tableTennisInfoRegistration(@RequestBody TableTennisInfoRegistrationRequestDTO tableTennisInfoRegistrationRequestDTO) {
     BooleanResponseDTO booleanResponseDTO = userService.tableTennisInfoRegistration(tableTennisInfoRegistrationRequestDTO);
-      return ResponseEntity.ok(booleanResponseDTO);
+    return ResponseEntity.ok(booleanResponseDTO);
+  }
+
+  @Operation(summary = "accessToken 재발급", description = "refreshToken을 통해 accessToken을 재발급 받는 API", security = @SecurityRequirement(name = "JWT"))
+  @ApiResponse(
+    responseCode = "200",
+    description = "새로 발급받은 accessToken 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = RefreshAccessTokenResponseDTO.class)
+    )
+  )
+  @GetMapping("/accessToken")
+  public ResponseEntity<RefreshAccessTokenResponseDTO> refreshAccessToken(@RequestHeader("Authorization") String refreshToken) {
+    RefreshAccessTokenResponseDTO refreshAccessTokenResponseDTO = tokenService.refreshAccessTokenByRefreshToken(refreshToken);
+    return ResponseEntity.ok(refreshAccessTokenResponseDTO);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/dto/RefreshAccessTokenResponseDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/RefreshAccessTokenResponseDTO.java
@@ -1,0 +1,16 @@
+package com.giho.king_of_table_tennis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@Schema(description = "accessToken 재발급 응답 DTO")
+public class RefreshAccessTokenResponseDTO {
+  private String newAccessToken;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
+++ b/src/main/java/com/giho/king_of_table_tennis/jwt/JWTUtil.java
@@ -59,4 +59,8 @@ public class JWTUtil {
       .signWith(secretKey)
       .compact();
   }
+
+  public String getTokenWithoutBearer(String token) {
+    return token.substring(7);
+  }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/TokenService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/TokenService.java
@@ -1,0 +1,28 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.RefreshAccessTokenResponseDTO;
+import com.giho.king_of_table_tennis.jwt.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+  private final JWTUtil jwtUtil;
+
+  @Value("${ACCESS_TOKEN_EXP}")
+  private long accessTokenExp;
+
+  public RefreshAccessTokenResponseDTO refreshAccessTokenByRefreshToken(String token) {
+    String refreshToken = jwtUtil.getTokenWithoutBearer(token);
+
+    String userId = jwtUtil.getUserId(refreshToken);
+    String role = jwtUtil.getRole(refreshToken);
+
+    String newAccessToken = jwtUtil.createJwt("access", userId, role, accessTokenExp);
+
+    return new RefreshAccessTokenResponseDTO(newAccessToken);
+  }
+}


### PR DESCRIPTION
## 📌 개요
- refreshToken으로 accessToken 재발급 받는 API

---

## ✅ 작업 내용
- refreshToken으로 accessToken 재발급 받는 API
  - accessToken이 만료되었을 때 refreshToken을 통해 새로운 accessToken을 발급 받음
  - 예상하는 프론트에서의 요청 흐름
    1. 헤더의 "Authentication"에 "Bearer "를 붙인 accessToken을 포함시켜 요청을 보냄 -> accessToken 만료
    2. 헤더의 "Authentication"에 "Bearer "를 붙인 refreshToken을 포함시켜 요청을 보냄 -> accessToken 재발급
       - 만약 refreshToken도 만료가 됐다면 프론트에서 로그인 화면으로 넘어가 다시 로그인하도록 유도
    3. 헤더의 "Authentication"에 "Bearer "를 붙인 새로운 accessToken을 포함시켜 요청을 보냄 -> 요청 성공

---

## 🔍 테스트 방법
Swagger UI와 PostMan으로 가능
http://localhost:8080/swagger-ui.html

- refreshToken으로 accessToken 재발급 받는 API
  - Postman으로 'GET /api/user/accessToken' 호출
  - Headers의 "Authorization"에 "Bearer "를 붙인 JWT 토큰(refreshToken) 입력

```jsonc
Headers 예시

"Authorization": "Bearer {refreshToken}"


응답형식(JSON)
{
    "newAccessToken": "새로운 accessToken"
}
```