### PR TITLE
Feature/game

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     // Google API Client Library for Java
     implementation 'com.google.api-client:google-api-client:2.7.2'
+
+    // MongoDB DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
+++ b/src/main/java/com/giho/king_of_table_tennis/KingOfTableTennisApplication.java
@@ -13,6 +13,7 @@ public class KingOfTableTennisApplication {
     Dotenv dotenv = Dotenv.configure().load();
 
     System.setProperty("MYSQL_PASSWORD", dotenv.get("MYSQL_PASSWORD"));
+    System.setProperty("MONGODB_URL", dotenv.get("MONGODB_URL"));
     System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
     System.setProperty("ACCESS_TOKEN_EXP", dotenv.get("ACCESS_TOKEN_EXP"));
     System.setProperty("REFRESH_TOKEN_EXP", dotenv.get("REFRESH_TOKEN_EXP"));

--- a/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
@@ -2,6 +2,7 @@ package com.giho.king_of_table_tennis.controller;
 
 import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
 import com.giho.king_of_table_tennis.dto.CreateGameRequestDTO;
+import com.giho.king_of_table_tennis.dto.SelectedGameDateResponseDTO;
 import com.giho.king_of_table_tennis.service.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,10 +12,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,5 +35,20 @@ public class GameController {
   public ResponseEntity<BooleanResponseDTO> createGame(@RequestBody CreateGameRequestDTO createGameRequestDTO) {
     BooleanResponseDTO booleanResponseDTO = gameService.createGame(createGameRequestDTO);
     return ResponseEntity.ok(booleanResponseDTO);
+  }
+
+  @Operation(summary = "선택 불가능한 날짜 가져오기", description = "게임 생성을 할 때 선택 불가능한 날짜를 가져오는 API", security = @SecurityRequirement(name = "JWT"))
+  @ApiResponse(
+    responseCode = "200",
+    description = "선택 불가능한 날짜 리스트 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = SelectedGameDateResponseDTO.class)
+    )
+  )
+  @GetMapping("/selectedGameDate/{tableTennisCourtId}")
+  public ResponseEntity<SelectedGameDateResponseDTO> getSelectedGameDate(@PathVariable String tableTennisCourtId) {
+    SelectedGameDateResponseDTO selectedGameDateResponseDTO = gameService.getSelectedGameDate(tableTennisCourtId);
+    return ResponseEntity.ok(selectedGameDateResponseDTO);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
@@ -2,6 +2,7 @@ package com.giho.king_of_table_tennis.controller;
 
 import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
 import com.giho.king_of_table_tennis.dto.CreateGameRequestDTO;
+import com.giho.king_of_table_tennis.dto.GameParticipationRequestDTO;
 import com.giho.king_of_table_tennis.dto.SelectedGameDateResponseDTO;
 import com.giho.king_of_table_tennis.service.GameService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,5 +51,20 @@ public class GameController {
   public ResponseEntity<SelectedGameDateResponseDTO> getSelectedGameDate(@PathVariable String tableTennisCourtId) {
     SelectedGameDateResponseDTO selectedGameDateResponseDTO = gameService.getSelectedGameDate(tableTennisCourtId);
     return ResponseEntity.ok(selectedGameDateResponseDTO);
+  }
+
+  @Operation(summary = "탁구 경기 참가 신청", description = "수락 타입에 따라 탁구 경기 참가 신청을 하는 API", security = @SecurityRequirement(name = "JWT"))
+  @ApiResponse(
+    responseCode = "200",
+    description = "탁구 경기 참가 신청 완료 여부 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = BooleanResponseDTO.class)
+    )
+  )
+  @PostMapping("/participation")
+  public ResponseEntity<BooleanResponseDTO> gameParticipation(@RequestBody GameParticipationRequestDTO gameParticipationRequestDTO) {
+    BooleanResponseDTO booleanResponseDTO = gameService.gameParticipation(gameParticipationRequestDTO);
+    return ResponseEntity.ok(booleanResponseDTO);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/GameController.java
@@ -1,0 +1,41 @@
+package com.giho.king_of_table_tennis.controller;
+
+import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
+import com.giho.king_of_table_tennis.dto.CreateGameRequestDTO;
+import com.giho.king_of_table_tennis.service.GameService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Game-Controller", description = "게임 관련 API")
+@RequestMapping("/api/game")
+public class GameController {
+
+  private final GameService gameService;
+
+  @Operation(summary = "게임 생성", description = "게임 생성을 위해 입력한 정보를 저장하는 API", security = @SecurityRequirement(name = "JWT"))
+  @ApiResponse(
+    responseCode = "200",
+    description = "GameInfo와 GameState 저장 성공 여부 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = BooleanResponseDTO.class)
+    )
+  )
+  @PostMapping("")
+  public ResponseEntity<BooleanResponseDTO> createGame(@RequestBody CreateGameRequestDTO createGameRequestDTO) {
+    BooleanResponseDTO booleanResponseDTO = gameService.createGame(createGameRequestDTO);
+    return ResponseEntity.ok(booleanResponseDTO);
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/controller/TableTennisCourtController.java
+++ b/src/main/java/com/giho/king_of_table_tennis/controller/TableTennisCourtController.java
@@ -1,0 +1,40 @@
+package com.giho.king_of_table_tennis.controller;
+
+import com.giho.king_of_table_tennis.dto.TableTennisCourtResponseDTO;
+import com.giho.king_of_table_tennis.service.TableTennisCourtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "TableTennisCourt-Controller", description = "탁구장 관련 API")
+@RequestMapping("/api/ttc")
+public class TableTennisCourtController {
+
+  private final TableTennisCourtService tableTennisCourtService;
+
+  @Operation(summary = "탁구장 검색", description = "name으로 탁구장들을 검색하는 API", security = @SecurityRequirement(name = "JWT"))
+  @ApiResponse(
+    responseCode = "200",
+    description = "탁구장 리스트 반환",
+    content = @Content(
+      mediaType = "application/json",
+      schema = @Schema(implementation = TableTennisCourtResponseDTO.class)
+    )
+  )
+  @GetMapping("/{name}")
+  public ResponseEntity<TableTennisCourtResponseDTO> searchTableTennisCourtByName(@PathVariable String name) {
+    TableTennisCourtResponseDTO tableTenniscourtResponseDTO = tableTennisCourtService.searchTableTennisCourtByName(name);
+    return ResponseEntity.ok(tableTenniscourtResponseDTO);
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/CreateGameRequestDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/CreateGameRequestDTO.java
@@ -1,0 +1,20 @@
+package com.giho.king_of_table_tennis.dto;
+
+import com.giho.king_of_table_tennis.entity.GameState;
+import com.giho.king_of_table_tennis.entity.GameType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "게임 만들기 요청 DTO")
+public class CreateGameRequestDTO {
+  private int gameSet;
+  private int targetScore;
+  private String place;
+  private GameType type;
+  private LocalDateTime date;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/CreateGameRequestDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/CreateGameRequestDTO.java
@@ -1,7 +1,6 @@
 package com.giho.king_of_table_tennis.dto;
 
-import com.giho.king_of_table_tennis.entity.GameState;
-import com.giho.king_of_table_tennis.entity.GameType;
+import com.giho.king_of_table_tennis.entity.AcceptanceType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,8 +12,8 @@ import java.time.LocalDateTime;
 @Schema(description = "게임 만들기 요청 DTO")
 public class CreateGameRequestDTO {
   private int gameSet;
-  private int targetScore;
+  private int gameScore;
   private String place;
-  private GameType type;
-  private LocalDateTime date;
+  private AcceptanceType acceptanceType;
+  private LocalDateTime gameDate;
 }

--- a/src/main/java/com/giho/king_of_table_tennis/dto/GameParticipationRequestDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/GameParticipationRequestDTO.java
@@ -1,0 +1,13 @@
+package com.giho.king_of_table_tennis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "게임 참가 요청 DTO")
+public class GameParticipationRequestDTO {
+  private String gameInfoId;
+  private String challengerId;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/SelectedGameDateResponseDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/SelectedGameDateResponseDTO.java
@@ -1,0 +1,17 @@
+package com.giho.king_of_table_tennis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Schema(description = "이미 선택된 탁구 경기 날짜 DTO")
+public class SelectedGameDateResponseDTO {
+  private List<LocalDateTime> selectedGameDateList;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/dto/TableTennisCourtResponseDTO.java
+++ b/src/main/java/com/giho/king_of_table_tennis/dto/TableTennisCourtResponseDTO.java
@@ -1,0 +1,17 @@
+package com.giho.king_of_table_tennis.dto;
+
+import com.giho.king_of_table_tennis.entity.TableTennisCourtEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Schema(description = "탁구장 정보 리스트 응답 DTO")
+public class TableTennisCourtResponseDTO {
+  private List<TableTennisCourtEntity> tableTennisCourts;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/AcceptanceType.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/AcceptanceType.java
@@ -1,6 +1,6 @@
 package com.giho.king_of_table_tennis.entity;
 
-public enum GameType {
+public enum AcceptanceType {
   FCFS, // 선착순 (first come, first served)
   SELECT // 게임 만든 사람이 선택
 }

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameApplicationEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameApplicationEntity.java
@@ -1,0 +1,27 @@
+package com.giho.king_of_table_tennis.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "game_application")
+public class GameApplicationEntity {
+
+  @Id
+  @Column(name = "id", nullable = false, unique = true)
+  private String id;
+
+  @Column(name = "applicant_id", nullable = false)
+  private String applicantId;
+
+  @Column(name = "application_at", nullable = false)
+  private LocalDateTime applicationAt;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameApplicationEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameApplicationEntity.java
@@ -19,6 +19,9 @@ public class GameApplicationEntity {
   @Column(name = "id", nullable = false, unique = true)
   private String id;
 
+  @Column(name = "game_info_id", nullable = false)
+  private String gameInfoId;
+
   @Column(name = "applicant_id", nullable = false)
   private String applicantId;
 

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameInfoEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameInfoEntity.java
@@ -19,16 +19,16 @@ public class GameInfoEntity {
   @Column(name = "game_set", nullable = false)
   private int gameSet;
 
-  @Column(name = "target_score", nullable = false)
-  private int targetScore;
+  @Column(name = "game_score", nullable = false)
+  private int gameScore;
 
   @Column(name = "place", nullable = false)
   private String place;
 
-  @Column(name = "type", nullable = false)
+  @Column(name = "acceptance_type", nullable = false)
   @Enumerated(EnumType.STRING)
-  private GameType type;
+  private AcceptanceType acceptanceType;
 
-  @Column(name = "date", nullable = false)
-  private LocalDateTime date;
+  @Column(name = "game_date", nullable = false)
+  private LocalDateTime gameDate;
 }

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameInfoEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameInfoEntity.java
@@ -1,0 +1,34 @@
+package com.giho.king_of_table_tennis.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "game_info")
+public class GameInfoEntity {
+
+  @Id
+  @Column(name = "id", nullable = false, unique = true)
+  private String id;
+
+  @Column(name = "game_set", nullable = false)
+  private int gameSet;
+
+  @Column(name = "target_score", nullable = false)
+  private int targetScore;
+
+  @Column(name = "place", nullable = false)
+  private String place;
+
+  @Column(name = "type", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private GameType type;
+
+  @Column(name = "date", nullable = false)
+  private LocalDateTime date;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameState.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameState.java
@@ -1,0 +1,8 @@
+package com.giho.king_of_table_tennis.entity;
+
+public enum GameState {
+  RECRUITING, // 상대 모집 중
+  WAITING, // 게임 시작 기다리는 중
+  DOING, // 게임 하는 중
+  END // 끝난 게임
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameStateEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameStateEntity.java
@@ -1,0 +1,32 @@
+package com.giho.king_of_table_tennis.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "game_state")
+public class GameStateEntity {
+
+  @Id
+  @Column(name = "game_info_id", nullable = false, unique = true)
+  private String gameInfoId;
+
+  @Column(name = "defender_id", nullable = false)
+  private String defenderId;
+
+  @Column(name = "challenger_id", nullable = true)
+  private String challengerId;
+
+  @Column(name = "defender_score", nullable = true)
+  private int defenderScore;
+
+  @Column(name = "challenger_score", nullable = true)
+  private int challenger_score;
+
+  @Column(name = "state", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private GameState state;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/GameType.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/GameType.java
@@ -1,0 +1,6 @@
+package com.giho.king_of_table_tennis.entity;
+
+public enum GameType {
+  FCFS, // 선착순 (first come, first served)
+  SELECT // 게임 만든 사람이 선택
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/Location.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/Location.java
@@ -1,0 +1,13 @@
+package com.giho.king_of_table_tennis.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Location {
+  private double latitude;
+  private double longitude;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/TableTennisCourt.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/TableTennisCourt.java
@@ -1,0 +1,25 @@
+package com.giho.king_of_table_tennis.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "tableTennisCourts")
+public class TableTennisCourt {
+  @Id
+  private String id;
+  private String name;
+  private String address;
+  private Location location;
+  private String phoneNumber;
+  private Map<String, String> businessHours;
+}

--- a/src/main/java/com/giho/king_of_table_tennis/entity/TableTennisCourtEntity.java
+++ b/src/main/java/com/giho/king_of_table_tennis/entity/TableTennisCourtEntity.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "tableTennisCourts")
-public class TableTennisCourt {
+public class TableTennisCourtEntity {
   @Id
   private String id;
   private String name;

--- a/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
+++ b/src/main/java/com/giho/king_of_table_tennis/exception/ErrorCode.java
@@ -15,6 +15,11 @@ public enum ErrorCode {
   // 탁구 정보
   TABLE_TENNIS_INFO_ALREADY_EXIST(HttpStatus.CONFLICT, "해당 사용자에 대한 탁구 정보가 이미 존재합니다."),
 
+  // 탁구 경기
+  GAME_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "탁구 경기를 찾을 수 없습니다."),
+  GAME_STATE_NOT_FOUND(HttpStatus.NOT_FOUND, "탁구 상태를 찾을 수 없습니다."),
+  GAME_NOT_RECRUITING(HttpStatus.NOT_FOUND, "상대방 모집중이 아닙니다."),
+
   // 인증번호 / 이메일
   VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
   INVALID_SESSION(HttpStatus.BAD_REQUEST, "세션이 유효하지 않습니다."),

--- a/src/main/java/com/giho/king_of_table_tennis/repository/GameApplicationRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/GameApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.giho.king_of_table_tennis.repository;
+
+import com.giho.king_of_table_tennis.entity.GameApplicationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameApplicationRepository extends JpaRepository<GameApplicationEntity, String> {
+}

--- a/src/main/java/com/giho/king_of_table_tennis/repository/GameInfoRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/GameInfoRepository.java
@@ -1,0 +1,7 @@
+package com.giho.king_of_table_tennis.repository;
+
+import com.giho.king_of_table_tennis.entity.GameInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameInfoRepository extends JpaRepository<GameInfoEntity, String> {
+}

--- a/src/main/java/com/giho/king_of_table_tennis/repository/GameInfoRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/GameInfoRepository.java
@@ -3,5 +3,10 @@ package com.giho.king_of_table_tennis.repository;
 import com.giho.king_of_table_tennis.entity.GameInfoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface GameInfoRepository extends JpaRepository<GameInfoEntity, String> {
+
+  List<GameInfoEntity> findAllByPlaceAndGameDateAfter(String place, LocalDateTime now);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/GameStateRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/GameStateRepository.java
@@ -1,0 +1,7 @@
+package com.giho.king_of_table_tennis.repository;
+
+import com.giho.king_of_table_tennis.entity.GameStateEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameStateRepository extends JpaRepository<GameStateEntity, String> {
+}

--- a/src/main/java/com/giho/king_of_table_tennis/repository/GameStateRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/GameStateRepository.java
@@ -3,5 +3,9 @@ package com.giho.king_of_table_tennis.repository;
 import com.giho.king_of_table_tennis.entity.GameStateEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GameStateRepository extends JpaRepository<GameStateEntity, String> {
+
+  Optional<GameStateEntity> findByGameInfoId(String gameInfoId);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
@@ -1,10 +1,10 @@
 package com.giho.king_of_table_tennis.repository;
 
-import com.giho.king_of_table_tennis.entity.TableTennisCourt;
+import com.giho.king_of_table_tennis.entity.TableTennisCourtEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface TableTennisCourtRepository extends MongoRepository<TableTennisCourt, String> {
-  Optional<TableTennisCourt> findByName(String name);
+public interface TableTennisCourtRepository extends MongoRepository<TableTennisCourtEntity, String> {
+  Optional<TableTennisCourtEntity> findByName(String name);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
@@ -2,9 +2,13 @@ package com.giho.king_of_table_tennis.repository;
 
 import com.giho.king_of_table_tennis.entity.TableTennisCourtEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TableTennisCourtRepository extends MongoRepository<TableTennisCourtEntity, String> {
   Optional<TableTennisCourtEntity> findByName(String name);
+
+  List<TableTennisCourtEntity> findAllByNameContainingIgnoreCase(String name);
 }

--- a/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
+++ b/src/main/java/com/giho/king_of_table_tennis/repository/TableTennisCourtRepository.java
@@ -1,0 +1,10 @@
+package com.giho.king_of_table_tennis.repository;
+
+import com.giho.king_of_table_tennis.entity.TableTennisCourt;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface TableTennisCourtRepository extends MongoRepository<TableTennisCourt, String> {
+  Optional<TableTennisCourt> findByName(String name);
+}

--- a/src/main/java/com/giho/king_of_table_tennis/service/GameService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/GameService.java
@@ -1,0 +1,57 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
+import com.giho.king_of_table_tennis.dto.CreateGameRequestDTO;
+import com.giho.king_of_table_tennis.entity.GameInfoEntity;
+import com.giho.king_of_table_tennis.entity.GameState;
+import com.giho.king_of_table_tennis.entity.GameStateEntity;
+import com.giho.king_of_table_tennis.repository.GameApplicationRepository;
+import com.giho.king_of_table_tennis.repository.GameInfoRepository;
+import com.giho.king_of_table_tennis.repository.GameStateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GameService {
+
+  private final GameInfoRepository gameInfoRepository;
+
+  private final GameStateRepository gameStateRepository;
+
+  private final GameApplicationRepository gameApplicationRepository;
+
+  @Transactional
+  public BooleanResponseDTO createGame(CreateGameRequestDTO createGameRequestDTO) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String userId = authentication.getName();
+
+    String gameInfoId = UUID.randomUUID().toString();
+
+    GameInfoEntity gameInfoEntity = new GameInfoEntity();
+
+    gameInfoEntity.setId(gameInfoId);
+    gameInfoEntity.setGameSet(createGameRequestDTO.getGameSet());
+    gameInfoEntity.setTargetScore(createGameRequestDTO.getTargetScore());
+    gameInfoEntity.setPlace(createGameRequestDTO.getPlace());
+    gameInfoEntity.setType(createGameRequestDTO.getType());
+    gameInfoEntity.setDate(createGameRequestDTO.getDate());
+
+    GameStateEntity gameStateEntity = new GameStateEntity();
+
+    gameStateEntity.setGameInfoId(gameInfoId);
+    gameStateEntity.setDefenderId(userId);
+    gameStateEntity.setState(GameState.RECRUITING);
+
+    gameInfoRepository.save(gameInfoEntity);
+
+    gameStateRepository.save(gameStateEntity);
+
+    return new BooleanResponseDTO(true);
+  }
+}

--- a/src/main/java/com/giho/king_of_table_tennis/service/GameService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/GameService.java
@@ -2,6 +2,7 @@ package com.giho.king_of_table_tennis.service;
 
 import com.giho.king_of_table_tennis.dto.BooleanResponseDTO;
 import com.giho.king_of_table_tennis.dto.CreateGameRequestDTO;
+import com.giho.king_of_table_tennis.dto.SelectedGameDateResponseDTO;
 import com.giho.king_of_table_tennis.entity.GameInfoEntity;
 import com.giho.king_of_table_tennis.entity.GameState;
 import com.giho.king_of_table_tennis.entity.GameStateEntity;
@@ -14,6 +15,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -37,10 +40,10 @@ public class GameService {
 
     gameInfoEntity.setId(gameInfoId);
     gameInfoEntity.setGameSet(createGameRequestDTO.getGameSet());
-    gameInfoEntity.setTargetScore(createGameRequestDTO.getTargetScore());
+    gameInfoEntity.setGameScore(createGameRequestDTO.getGameScore());
     gameInfoEntity.setPlace(createGameRequestDTO.getPlace());
-    gameInfoEntity.setType(createGameRequestDTO.getType());
-    gameInfoEntity.setDate(createGameRequestDTO.getDate());
+    gameInfoEntity.setAcceptanceType(createGameRequestDTO.getAcceptanceType());
+    gameInfoEntity.setGameDate(createGameRequestDTO.getGameDate());
 
     GameStateEntity gameStateEntity = new GameStateEntity();
 
@@ -53,5 +56,16 @@ public class GameService {
     gameStateRepository.save(gameStateEntity);
 
     return new BooleanResponseDTO(true);
+  }
+
+  public SelectedGameDateResponseDTO getSelectedGameDate(String tableTennisCourtId) {
+
+    List<GameInfoEntity> upComingGames = gameInfoRepository.findAllByPlaceAndGameDateAfter(tableTennisCourtId, LocalDateTime.now());
+
+    List<LocalDateTime> selectedGameDateList = upComingGames.stream()
+      .map(GameInfoEntity::getGameDate)
+      .toList();
+
+    return new SelectedGameDateResponseDTO(selectedGameDateList);
   }
 }

--- a/src/main/java/com/giho/king_of_table_tennis/service/TableTennisCourtService.java
+++ b/src/main/java/com/giho/king_of_table_tennis/service/TableTennisCourtService.java
@@ -1,0 +1,23 @@
+package com.giho.king_of_table_tennis.service;
+
+import com.giho.king_of_table_tennis.dto.TableTennisCourtResponseDTO;
+import com.giho.king_of_table_tennis.entity.TableTennisCourtEntity;
+import com.giho.king_of_table_tennis.repository.TableTennisCourtRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class TableTennisCourtService {
+
+  private final TableTennisCourtRepository tableTennisCourtRepository;
+
+  public TableTennisCourtResponseDTO searchTableTennisCourtByName(String name) {
+    List<TableTennisCourtEntity> tableTennisCourts = tableTennisCourtRepository.findAllByNameContainingIgnoreCase(name);
+
+    return new TableTennisCourtResponseDTO(tableTennisCourts);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       maximum-pool-size: 20
 
   data:
+    mongodb:
+      uri: ${MONGODB_URL}
     redis:
       host: localhost
       port: 6379


### PR DESCRIPTION
## 📌 개요
- 탁구장 정보를 저장한 MongoDB 연결
- 탁구장 정보 entity, repository 생성
- 탁구 경기 정보 entity, repository, controller, service 생성
- 탁구장 검색 API
- 탁구 경기 생성 API
- 탁구 경기 예약 시간 리스트 반환 API
- 탁구 경기 참가 신청 API

---

## ✅ 작업 내용
- 탁구장 정보를 저장한 MongoDB 연결
- 탁구장 정보 entity, repository 생성
```
{
  "_id": {
    "$oid": "687fcc0773c25268cad7d768"
  },
  "name": "서초탁구(클럽)",
  "address": "서울특별시 서초구 동광로 65",
  "location": {
    "latitude": 37.4927391,
    "longitude": 126.9896986
  },
  "phoneNumber": "02-596-4787",
  "businessHours": {
    "수요일": "24시간 영업",
    "목요일": "24시간 영업",
    "금요일": "24시간 영업",
    "토요일": "24시간 영업",
    "일요일": "24시간 영업",
    "월요일": "24시간 영업",
    "화요일": "24시간 영업"
  }
}
```

- 탁구 경기 정보 entity, repository, controller, service 생성
  - GameInfoEntity: 탁구 경기 정보에 대한 내용
  - GameStateEntity: 탁구 경기에 대한 내용
  - GameApplication: 수락 타입이 선택일 경우 사용되는 탁구 경기 신청
  - AcceptanceType(enum): FCFS(선착순), SELECT(선택) / 수락 타입
  - GameState(enum): RECRUITING(모집 중), WAITING(경기 기다리는 중), DOING(경기 중), END(경기 종료) / 경기 상태
- 탁구장 검색 API
  - 키워드를 통해 탁구장을 검색, 이름에 키워드가 포함되는 탁구장 리스트 반환
- 탁구 경기 생성 API
  - 경기 세트 수와 점수, 상대방 수락 타입, 경기 날짜를 통해 GameInfo와 GameState(RECRUITING/모집 중 상태로)를 저장
- 탁구 경기 예약 시간 리스트 반환 API
  - 탁구장 별 시간 당 경기는 한 경기로 제한해두기 때문에 이미 경기가 있는 시간은 고를 수 없음
  - 현재 시간 이후의 경기 날짜와 시간을 반환함으로써 프론트에서 선택 불가능하게 함
- 탁구 경기 참가 신청 API
  - gameInfoId를 통해 탁구 경기를 찾고, 수락 타입에 따라 다르게 처리
    - FCFS(선착순): gameState의 state를 WAITING으로 변경, challengerId에 신청자 아이디 저장
    - FCFS(선택): gameState를 변경하지 않고 GameApplication에 신청자의 아이디와 신청 날짜를 저장해 추후 경기 생성자가 선택할 수 있도록 함

---

## 🔍 테스트 방법
Swagger UI와 PostMan으로 가능
http://localhost:8080/swagger-ui.html

- 탁구장 검색 API
  - Postman으로 'GET /api/ttc/{keyword}' 호출
  - Headers의 "Authorization"에 "Bearer "를 붙인 JWT 토큰 입력
```jsonc
"tableTennisCourts": [
        {
            "id": "687fcc0773c25268cad7d768",
            "name": "서초탁구(클럽)",
            "address": "서울특별시 서초구 동광로 65",
            "location": {
                "latitude": 37.4927391,
                "longitude": 126.9896986
            },
            "phoneNumber": "02-596-4787",
            "businessHours": {
                "수요일": "24시간 영업",
                "목요일": "24시간 영업",
                "금요일": "24시간 영업",
                "토요일": "24시간 영업",
                "일요일": "24시간 영업",
                "월요일": "24시간 영업",
                "화요일": "24시간 영업"
            }
        },
       { 
       
       }
]
```
- 탁구 경기 생성 API
  - Postman으로 'POST /api/game' 호출
  - Headers의 "Authorization"에 "Bearer "를 붙인 JWT 토큰 입력
```jsonc
요청 body 예시 (raw - JSON 선택)
{
    "gameSet": 3,
    "targetScore": 11,
    "place": "687fcc0e73c25268cad7d769",
    "type": "FCFS",
    "date": "2025-07-24T18:00:00"
}
```
```jsonc
응답 예시
{
    "success": true
}
```
- 탁구 경기 예약 시간 리스트 반환 API
  - Postman으로 'GET /api/game/selectedGameDate/{tableTennisCourtId}' 호출
  - Headers의 "Authorization"에 "Bearer "를 붙인 JWT 토큰 입력
```jsonc
응답 예시
{
    "selectedGameDateList": [
        "2025-08-27T01:00:00",
        "2025-08-29T12:00:00"
    ]
}
```
- 탁구 경기 참가 신청 API
  - Postman으로 'GET /api/game/participation' 호출
  - Headers의 "Authorization"에 "Bearer "를 붙인 JWT 토큰 입력
```jsonc
요청 body 예시 (raw - JSON 선택)
{
    "gameInfoId": "4f98728d-b615-4543-ae22-11e3fed99c3e",
    "challengerId": "asdfasdf"
}
```
```jsonc
응답 예시
{
    "success": true
}
```

## 📋 해야할 것
- 탁구 경기 참가 신청 API에서 동시에 같은 경기로 여러 명이 요청을 했을 때 정상적으로 작동하는지 확인(선착순에서)
  - 테스트 코드 작성

## 📄 추가된 데이터베이스
```sql
CREATE TABLE game_info (
    id VARCHAR(255) NOT NULL PRIMARY KEY, -- 게임 고유 아이디
    game_set INT NOT NULL, -- 게임 진행 세트 / 3, 5
    game_score INT NOT NULL, -- 한 세트 점수 / 11, 21
    place VARCHAR(255) NOT NULL, -- 탁구장 아이디 / table_tennis_courts
    acceptance_type VARCHAR(255) NOT NULL, -- 게임 수락 타입 / FCFS(선착순), SELECT(선택)
    game_date TIMESTAMP NOT NULL -- 게임 날짜
);
```
```sql
CREATE TABLE game_state (
    game_info_id VARCHAR(255) NOT NULL PRIMARY KEY,
    defender_id VARCHAR(255) NOT NULL, -- 게임 만든 사람 아이디
    challenger_id VARCHAR(255), -- 게임 참가한 사람 아이디, 탁구 경기 참가 신청 전에는 null
    defender_score INT, -- 게임 만든 사람 점수, 게임 전에는 초기값 0
    challenger_score INT, -- 게임 참가한 사람 점수, 게임 전에는 초기값 0
    state VARCHAR(255) NOT NULL -- 게임 상태 / RECRUITING(모집 중), WAITING(경기 기다리는 중), DOING(경기 중), END(경기 종료)
);
```
```sql
CREATE TABLE game_application ( -- 게임 수락 타입이 선택일 경우, 신청서
    id VARCHAR(255) NOT NULL PRIMARY KEY,
    game_info_id VARCHAR(255) NOT NULL,
    applicant_id VARCHAR(255) NOT NULL, -- 신청자 아이디
    application_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP -- 신청 날짜
);
```